### PR TITLE
fix peerDependencies requirements

### DIFF
--- a/examples/systemjs/package.json
+++ b/examples/systemjs/package.json
@@ -15,10 +15,10 @@
   },
   "dependencies": {
     "angular2": "^2.0.0-beta.0",
-    "angular2-library-example": "^1.0.2",
-    "es6-shim": "^0.34.0",
+    "angular2-library-example": "https://github.com/timoweiss/angular2-library-example.git",
+    "es6-shim": "^0.35.0",
     "http-server": "^0.8.5",
-    "reflect-metadata": "^0.1.2",
+    "reflect-metadata": "0.1.2",
     "systemjs": "^0.19.9"
   }
 }

--- a/examples/systemjs/package.json
+++ b/examples/systemjs/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "angular2": "^2.0.0-beta.0",
-    "angular2-library-example": "https://github.com/timoweiss/angular2-library-example.git",
+    "angular2-library-example": "^1.0.2",
     "es6-shim": "^0.35.0",
     "http-server": "^0.8.5",
     "reflect-metadata": "0.1.2",

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -30,11 +30,11 @@
     "angular2": "^2.0.0-beta.0",
     "angular2-library-example": "^1.0.6",
     "es6-promise": "^3.0.2",
-    "es6-shim": "^0.34.0",
+    "es6-shim": "^0.35.0",
     "ng2-translate": "^1.2.4",
-    "reflect-metadata": "^0.1.2",
-    "rxjs": "^5.0.0-beta.0",
+    "reflect-metadata": "0.1.2",
+    "rxjs": "5.0.0-beta.2",
     "ts-loader": "^0.7.2",
-    "zone.js": "^0.5.10"
+    "zone.js": "^0.6.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
   },
   "dependencies": {
     "angular2": "2.0.0-beta.0",
-    "rxjs": "^5.0.0-beta.0"
+    "rxjs": "5.0.0-beta.0"
   }
 }


### PR DESCRIPTION
```
npm ERR! peerinvalid The package rxjs@5.0.0-beta.4 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer angular2@2.0.0-beta.0 wants rxjs@5.0.0-beta.0
```

and many others :)
