### PR TITLE
Upgrade to Angular 2.0.0-rc.1

### DIFF
--- a/examples/systemjs/index.html
+++ b/examples/systemjs/index.html
@@ -5,25 +5,58 @@
     <meta charset="UTF-8">
     <title>Example TODO Application using the ng2-store</title>
 
-    <script src="/node_modules/angular2/bundles/angular2-polyfills.js"></script>
-    <script src="/node_modules/es6-shim/es6-shim.min.js"></script>
-    <script src="/node_modules/systemjs/dist/system.src.js"></script>
-    <script src="/node_modules/angular2/bundles/http.min.js"></script>
+    <script src="node_modules/zone.js/dist/zone.js"></script>
+    <script src="node_modules/reflect-metadata/Reflect.js"></script>
+    <script src="node_modules/core-js/client/shim.min.js"></script>
+    <script src="node_modules/systemjs/dist/system.src.js"></script>
+
 
     <script>
-        System.config({
-            defaultJSExtensions: true,
-            packages: {
-                "/angular2": {"defaultExtension": false}
-            },
-            map: {
-                'angular2-library-example': 'node_modules/angular2-library-example'
-            }
+        var packages = {
+            'app': {main: 'main.js', defaultExtension: 'js'},
+            'rxjs': {defaultExtension: 'js'},
+            'angular2-in-memory-web-api': {defaultExtension: 'js'},
+        };
+
+        var packageNames = [
+            '@angular/common',
+            '@angular/compiler',
+            '@angular/core', // <--------
+            '@angular/http',
+            '@angular/platform-browser',
+            '@angular/platform-browser-dynamic',
+            '@angular/router',
+            '@angular/router-deprecated',
+            '@angular/testing',
+            '@angular/upgrade'
+        ];
+
+        packageNames.forEach(function (pkgName){
+            packages[pkgName] = {main: 'index.js', defaultExtension: 'js'};
         });
+
+        var map = {
+            '@angular': 'node_modules/@angular',
+            'rxjs': 'node_modules/rxjs',
+            'angular2-library-example': 'node_modules/angular2-library-example'
+        };
+
+        var config = {
+            defaultJSExtensions: true,
+            map: map,
+            packages: packages
+        };
+
+        System.config(config);
+
     </script>
 
-    <script src="/node_modules/rxjs/bundles/Rx.js"></script>
-    <script src="/node_modules/angular2/bundles/angular2.js"></script>
+    <script src="node_modules/rxjs/bundles/Rx.umd.js"></script>
+    <script src="node_modules/@angular/core/core.umd.js"></script>
+    <script src="node_modules/@angular/common/common.umd.js"></script>
+    <script src="node_modules/@angular/compiler/compiler.umd.js"></script>
+    <script src="node_modules/@angular/platform-browser/platform-browser.umd.js"></script>
+    <script src="node_modules/@angular/platform-browser-dynamic/platform-browser-dynamic.umd.js"></script>
 
     <script>
         System.import('build/App').catch(console.log.bind(console));

--- a/examples/systemjs/package.json
+++ b/examples/systemjs/package.json
@@ -14,11 +14,20 @@
     "typescript": "^1.7.5"
   },
   "dependencies": {
-    "angular2": "^2.0.0-beta.0",
-    "angular2-library-example": "^1.0.2",
-    "es6-shim": "^0.35.0",
     "http-server": "^0.8.5",
+    "systemjs": "^0.19.9",
+    "@angular/common":  "2.0.0-rc.1",
+    "@angular/compiler":  "2.0.0-rc.1",
+    "@angular/core":  "2.0.0-rc.1",
+    "@angular/http":  "2.0.0-rc.1",
+    "@angular/platform-browser":  "2.0.0-rc.1",
+    "@angular/platform-browser-dynamic":  "2.0.0-rc.1",
+    "rxjs": "5.0.0-beta.6",
+    "zone.js":"^0.6.12",
+    "angular2-library-example": "^1.0.6",
+    "es6-promise": "^3.0.2",
+    "core-js": "^2.4.0",
     "reflect-metadata": "0.1.2",
-    "systemjs": "^0.19.9"
+    "ts-loader": "^0.8.2"
   }
 }

--- a/examples/systemjs/src/App.ts
+++ b/examples/systemjs/src/App.ts
@@ -1,6 +1,6 @@
 
-import {Component} from 'angular2/core';
-import {bootstrap} from 'angular2/platform/browser';
+import {Component} from '@angular/core';
+import {bootstrap} from '@angular/platform-browser-dynamic';
 import {HelloWorld} from 'angular2-library-example/components';
 
 

--- a/examples/systemjs/src/tsconfig.json
+++ b/examples/systemjs/src/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",
     "removeComments": true,

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -27,14 +27,18 @@
     "webpack-dev-server": "^1.14.0"
   },
   "dependencies": {
-    "angular2": "^2.0.0-beta.0",
+    "@angular/common": "2.0.0-rc.1",
+    "@angular/compiler": "2.0.0-rc.1",
+    "@angular/core": "2.0.0-rc.1",
+    "@angular/http": "2.0.0-rc.1",
+    "@angular/platform-browser": "2.0.0-rc.1",
+    "@angular/platform-browser-dynamic": "2.0.0-rc.1",
+    "rxjs": "5.0.0-beta.6",
+    "zone.js": "^0.6.12",
     "angular2-library-example": "^1.0.6",
     "es6-promise": "^3.0.2",
-    "es6-shim": "^0.35.0",
-    "ng2-translate": "^1.2.4",
+    "core-js": "^2.4.0",
     "reflect-metadata": "0.1.2",
-    "rxjs": "5.0.0-beta.2",
-    "ts-loader": "^0.7.2",
-    "zone.js": "^0.6.6"
+    "ts-loader": "^0.8.2"
   }
 }

--- a/examples/webpack/src/app.ts
+++ b/examples/webpack/src/app.ts
@@ -1,6 +1,8 @@
-import 'angular2/bundles/angular2-polyfills';
-import {Component} from 'angular2/core';
-import {bootstrap} from 'angular2/platform/browser';
+import 'zone.js/dist/zone';
+import 'reflect-metadata';
+
+import {Component} from '@angular/core';
+import {bootstrap} from '@angular/platform-browser-dynamic';
 import {HelloWorld} from 'angular2-library-example/components';
 
 

--- a/examples/webpack/tsconfig.json
+++ b/examples/webpack/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",
     "removeComments": true,

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -1,16 +1,27 @@
+var path = require('path');
+
 module.exports = {
-    entry: "./src/app.ts",
-    output: {
-        filename: "bundle.js"
-    },
-    devtool: 'source-map',
-    resolve: {
-        extensions: ['', '.webpack.js', '.web.js', '.ts',  '.js']
-    },
-    module: {
-        loaders: [
-            { test: /\.ts$/, loader: 'ts-loader' }
-        ]
-    },
-    noParse: [ /.+zone\.js\/dist\/.+/, /.+angular2\/bundles\/.+/ ]
+  entry: "./src/app.ts",
+  output: {
+    filename: "bundle.js"
+  },
+  devtool: 'source-map',
+
+  resolve: {
+    extensions: ['', '.webpack.js', '.web.js', '.ts', '.js'],
+    // Two lines below fix dependency resolution when npm linking the component.
+    fallback: path.join(__dirname, "node_modules")
+  },
+  resolveLoader: {fallback: path.join(__dirname, "node_modules")},
+
+  module: {
+    loaders: [
+      {
+        test: /\.ts$/, loader: 'ts-loader'
+      }
+    ]
+  },
+  noParse: [
+    path.join(__dirname, 'node_modules', 'zone.js', 'dist')
+  ]
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,13 @@
     "typescript": "^1.7.5"
   },
   "dependencies": {
-    "angular2": "2.0.0-beta.0",
-    "rxjs": "5.0.0-beta.0"
+    "@angular/common": "2.0.0-rc.1",
+    "@angular/compiler": "2.0.0-rc.1",
+    "@angular/core": "2.0.0-rc.1",
+    "@angular/http": "2.0.0-rc.1",
+    "@angular/platform-browser": "2.0.0-rc.1",
+    "@angular/platform-browser-dynamic": "2.0.0-rc.1",
+    "rxjs": "5.0.0-beta.6",
+    "zone.js":"^0.6.12"
   }
 }

--- a/src/HelloWorld.ts
+++ b/src/HelloWorld.ts
@@ -1,5 +1,4 @@
-
-import {Component} from 'angular2/core';
+import {Component} from '@angular/core';
 
 @Component({
     selector: 'hello-world',

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",
     "removeComments": true,


### PR DESCRIPTION
- Upgrade to Angular 2.0.0-rc.1
- Switch `TS` compile target to `es6` to get rid of compile errors.
- Add additional resolution rules to `webpack` config to allow using npm link.
